### PR TITLE
Fully disconnect when remote server ends connection.

### DIFF
--- a/ssheven-net.c
+++ b/ssheven-net.c
@@ -622,7 +622,7 @@ void* read_thread(void* arg)
 	// disallow pasting after connection is closed
 	DisableItem(menu, 5);
 
-    // If the remote server closes the client connection unexpectedly, call "disconnect()
+    // If the remote server closes the client connection unexpectedly, call disconnect()
     // to release memory and avoid the user having to manually select Disconnect and then
     // Connect.. from the file menu.
 

--- a/ssheven-net.c
+++ b/ssheven-net.c
@@ -622,5 +622,12 @@ void* read_thread(void* arg)
 	// disallow pasting after connection is closed
 	DisableItem(menu, 5);
 
+    // If the remote server closes the client connection unexpectedly, call "disconnect()
+    // to release memory and avoid the user having to manually select Disconnect and then
+    // Connect.. from the file menu.
+
+    disconnect();
+
+
 	return 0;
 }


### PR DESCRIPTION
When the remote server ends the connection, the message `(disconnected by server)` is presented, but ssheven is not in a state that is ready to start a new connection. This change prevents the user from having to select File>Disconnect before selecting File>Connect.. for a new session.